### PR TITLE
Drop USER hack

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: dd01e07a77123c128ff79ba57b97c1d7
 
 build:
-  number: 0
+  number: 1
   osx_is_app: True
 
 requirements:
@@ -32,8 +32,7 @@ requirements:
 
 test:
   commands:
-    - USER=test spyder -h  # [unix]
-    - spyder -h  # [win]
+    - spyder -h
   imports:
     - spyderlib
 


### PR DESCRIPTION
Drops the `USER` setting hack needed in staged-recipes as `USER` was not defined in the Docker container. As it is now defined, this hack can be dropped.

xref: https://github.com/conda-forge/staged-recipes/pull/477/files#diff-73b2285b9f26016fd8047c0abb4b1977R35
xref: https://github.com/conda-forge/docker-images/issues/6
xref: https://github.com/conda-forge/docker-images/pull/28

Edit: ~~Currently includes the re-rendering from PR ( https://github.com/conda-forge/spyder-feedstock/pull/2 ), but that can be removed once that PR is merged.~~ This has been rebased out.