### PR TITLE
Pin pyqt to 4.11 for macOS until conda-forge packages for Qt 5 are created

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
   run:
     - python
     - pyqt
+    - pyqt 4.11.*  # [osx]
     - qtpy >=1.1
     - qtawesome >=0.4.1
     - rope >=0.9.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
   entry_points:
     - spyder = spyder.app.start:main
   osx_is_app: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - sphinx
   run:
     - python
-    - pyqt
+    - pyqt  # [linux or win]
     - pyqt 4.11.*  # [osx]
     - qtpy >=1.1
     - qtawesome >=0.4.1


### PR DESCRIPTION
@ocefpaf, please review. This is the right solution, instead of #16, in my opinion.