### PR TITLE
Demand PyQt5 for Spyder 3.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - zmq.patch
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - spyder = spyder.app.start:main
   osx_is_app: True
@@ -26,7 +26,7 @@ requirements:
     - sphinx
   run:
     - python
-    - pyqt
+    - pyqt 5.*
     - qtpy >=1.2.0
     - qtawesome >=0.4.1
     - rope >=0.9.4
@@ -45,7 +45,7 @@ requirements:
     - numpydoc
     - cloudpickle
     - keyring
-    - spyder-kernels <1.0
+    - spyder-kernels 0.*
     - python.app  # [osx]
 
 test:


### PR DESCRIPTION
We dropped support for PyQt4 in this version

----

@jjhelmus, @mingwandroid, @nehaljwani, I forgot to update this pin in my last PR.