### PR TITLE
Don't install keyring on Linux and Python 2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - zmq.patch
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - spyder = spyder.app.start:main
   osx_is_app: True
@@ -44,7 +44,7 @@ requirements:
     - chardet >=2.0
     - numpydoc
     - cloudpickle
-    - keyring
+    - keyring  # [not (linux and py2k)]
     - spyder-kernels 0.*
     - python.app  # [osx]
 


### PR DESCRIPTION
@jjhelmus, @mingwandroid, @nehaljwani, I forgot to add this selector in my previous build.

This is because `keyring`'s backend in Python 2 depends on system packages. I also added the same requirement to our wheels in Spyder 3.3.1