### PR TITLE
MAINT: Change the way loose versions are pinned

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - zmq.patch
 
 build:
-  number: 1
+  number: 2
   entry_points:
     - spyder = spyder.app.start:main
   osx_is_app: True
@@ -26,7 +26,7 @@ requirements:
     - sphinx
   run:
     - python
-    - pyqt 5.*
+    - pyqt =5
     - qtpy >=1.2.0
     - qtawesome >=0.4.1
     - rope >=0.9.4
@@ -45,7 +45,7 @@ requirements:
     - numpydoc
     - cloudpickle
     - keyring  # [not (linux and py2k)]
-    - spyder-kernels 0.*
+    - spyder-kernels =0
     - python.app  # [osx]
 
 test:


### PR DESCRIPTION
See Issue #38

This attempts to do loose version pinning with `=5` and `=0` to ensure the ipykernels 1.0 doesn't get pulled in.

XREF: https://github.com/conda-forge/spyder-kernels-feedstock/pull/17#issuecomment-424777973

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`