### PR TITLE
Allow PyQt 5.9 from conda-forge

### DIFF
--- a/.azure-pipelines/run_docker_build.sh
+++ b/.azure-pipelines/run_docker_build.sh
@@ -5,7 +5,7 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
-set -xeuo pipefail
+set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 PROVIDER_DIR="$(basename $THISDIR)"
@@ -28,12 +28,25 @@ fi
 ARTIFACTS="$FEEDSTOCK_ROOT/build_artifacts"
 
 if [ -z "$CONFIG" ]; then
-    echo "Need to set CONFIG env variable"
+    set +x
+    FILES=`ls .ci_support/linux_*`
+    CONFIGS=""
+    for file in $FILES; do
+        CONFIGS="${CONFIGS}'${file:12:-5}' or ";
+    done
+    echo "Need to set CONFIG env variable. Value can be one of ${CONFIGS:0:-4}"
     exit 1
 fi
 
-pip install shyaml
-DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )
+if [ -z "${DOCKER_IMAGE}" ]; then
+    SHYAML_INSTALLED="$(shyaml --version || echo NO)"
+    if [ "${SHYAML_INSTALLED}" == "NO" ]; then
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
+        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+    else
+        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
+    fi
+fi
 
 mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Current build status
       </details>
     </td>
   </tr>
+![ppc64le disabled](https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg)
 </table>
 
 Current release info

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - osx-zmq.patch
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - spyder = spyder.app.start:main
   osx_is_app: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - pylint
     # This is here to avoid mixing default and conda-forge
     # qt/pyqt packages.
-    - pyqt >=5.6,<5.7
+    - pyqt >=5.6,<5.10
     - python.app  # [osx]
     - pyzmq
     - qtawesome >=0.5.7


### PR DESCRIPTION
Now that there is a Qt 5.9 on conda-forge we can relax the `PyQt <5.7` restriction in this recipe. Otherwise I get an install of version 3.3.1 instead of 3.3.4. I left `<5.10` in place in case defaults updates to Qt 5.12 before conda-forge.

**I don't recommend merging yet** as there seems to be some problem with the Qt 5.9 package on conda-forge (at least for linux). I experienced [the following issue](https://gitter.im/conda-forge/conda-forge.github.io?at=5cd953f35a1d435d4633c1cf) and could not use the keyboard at all in the Spyder terminal or editor. 

As suggested by @hmaarfk, setting `export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb/` fixes the issue, but I don't think we should require that of users. Once the upstream Qt package has been fixed (see conda-forge/pyqt-feedstock#52), this should be good to go.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
