### PR TITLE
Patch for critical bug that prevents selecting custom interpreters in macOS

### DIFF
--- a/recipe/0002-Remove-PYTHONEXECUTABLE.patch
+++ b/recipe/0002-Remove-PYTHONEXECUTABLE.patch
@@ -1,0 +1,11 @@
+--- spyder/plugins/ipythonconsole/utils/kernelspec.py.old	2020-11-20 15:44:12.000000000 -0500
++++ spyder/plugins/ipythonconsole/utils/kernelspec.py	2021-01-10 12:56:04.050476445 -0500
+@@ -194,6 +194,8 @@
+             env_vars.pop('PYTHONHOME', None)
+             env_vars.pop('PYTHONPATH', None)
+ 
++        env_vars.pop('PYTHONEXECUTABLE', None)
++
+         # Making all env_vars strings
+         clean_env_vars = clean_env(env_vars)
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
     - osx-zmq.patch
     # Remove when 4.2.2 is released!
     - 0001-Don-t-open-script-that-starts-Spyder-at-startup.patch
+    - 0002-Remove-PYTHONEXECUTABLE.patch
 
 build:
-  number: 1
+  number: 2
   entry_points:
     - spyder = spyder.app.start:main
   osx_is_app: true


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This will be part of our next release (see https://github.com/spyder-ide/spyder/pull/14565), but I decided to include it as a patch against 4.2.1 because

- It's very small.
- It only happens in Anaconda.
- We've been trying to fix tihs problem for more than six months now.

<!--
Please add any other relevant info below:
-->
