### PR TITLE
Constrain jinja2 <3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,6 +72,7 @@ requirements:
 test:
   requires:
     - pip
+    - jinja2 <3.1 # numpydoc has this as a runtime version check
   commands:
     - USER=test spyder -h  # [unix]
     - spyder -h  # [win]


### PR DESCRIPTION
It looks like numpydoc 1.2.1 will dynamically check for a jinja <3.1,
but this isn't enforced by the conda system. So adding this requirement
is required to work with that numpydoc package.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
