### PR TITLE
PR: Bump `jedi` upper constraint to <0.20.0 and improve constraints for `ipython` and `pyqtwebengine` 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - osx-zmq.patch
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - spyder = spyder.app.start:main
   osx_is_app: true
@@ -35,7 +35,7 @@ requirements:
     - diff-match-patch >=20181111
     - intervaltree >=3.0.2
     - ipython >=7.31.1,<9.0.0,!=8.8.0,!=8.9.0,!=8.10.0,!=8.11.0,!=8.12.0,!=8.12.1,!=8.17.1
-    - jedi >=0.17.2,<0.19.0
+    - jedi >=0.17.2,<0.20.0
     - jellyfish >=0.7
     - jsonschema >=3.2.0
     - keyring >=17.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - cookiecutter >=1.6.0
     - diff-match-patch >=20181111
     - intervaltree >=3.0.2
-    - ipython >=7.31.1,<9.0.0,!=8.8.0,!=8.9.0,!=8.10.0,!=8.11.0,!=8.12.0,!=8.12.1,!=8.17.1
+    - ipython >=8.12.2,<9.0.0,!=8.17.1
     - jedi >=0.17.2,<0.20.0
     - jellyfish >=0.7
     - jsonschema >=3.2.0
@@ -54,7 +54,7 @@ requirements:
     - python-lsp-black >=1.2.0
     - pyls-spyder >=0.4.0
     - pyqt >=5.10,<5.16
-    - pyqtwebengine <5.16
+    - pyqtwebengine >=5.10,<5.16
     - python.app  # [osx]
     - python-lsp-server >=1.9.0,<1.10.0
     - pyxdg >=0.26  # [linux]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Missing bump for the `jedi` constraint done for Spyder 5.5.0 upstream: https://github.com/spyder-ide/spyder/pull/21367