### PR TITLE
Fix sed syntax and macOS bundle names with spaces

### DIFF
--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e
 
-[[ $(sed --version 2>/dev/null) ]] && opts=("-i" "-e") || opts=("-i" "" "-e")
+[[ $(sed --version 2>/dev/null) ]] && opts=("-i" "-E") || opts=("-i" "" "-E")
+menu="${PREFIX}/Menu/spyder-menu.json"
 
 if [[ -f "${PREFIX}/Menu/conda-based-app" ]]; then
     # Installed in installer environment, abridge shortcut name
-    menu="${PREFIX}/Menu/spyder-menu.json"
-    sed ${opts[@]} "s/ \(\{\{ ENV_NAME \}\}\)//g" $menu
+    sed "${opts[@]}" "s/ \(\{\{ ENV_NAME \}\}\)//g" $menu
 elif [[ -d "${PREFIX}/condabin" && -d "${PREFIX}/envs" ]]; then
     # Installed in a base environment, use distribution name
-    sed ${opts[@]} "s/ENV_NAME/DISTRIBUTION_NAME/g" $menu
+    sed "${opts[@]}" "s/ENV_NAME/DISTRIBUTION_NAME/g" $menu
 fi

--- a/recipe/spyder-menu.json
+++ b/recipe/spyder-menu.json
@@ -25,7 +25,8 @@
                     "StartupWMClass": "Spyder"
                 },
                 "osx": {
-                    "command": ["$(dirname $0)/python", "{{ PREFIX }}/bin/spyder", "$@"],
+                    "precommand": "pushd \"$(dirname \"$0\")\" &>/dev/null",
+                    "command": ["./python", "{{ PREFIX }}/bin/spyder", "$@"],
                     "link_in_bundle": {
                         "{{ PREFIX }}/bin/python": "{{ MENU_ITEM_LOCATION }}/Contents/MacOS/python"
                     },

--- a/recipe/spyder-menu.json
+++ b/recipe/spyder-menu.json
@@ -18,7 +18,7 @@
                 },
                 "linux": {
                     "Categories": [
-                        "Graphics",
+                        "Development",
                         "Science"
                     ],
                     "command": ["{{ PREFIX }}/bin/spyder", "$@"],


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Yet another fix:
* Fix issue with sed syntax
* Fix command quotes to accommodate bundle names with spaces for macOS