### PR TITLE
Include a menuinst v1 spec file in case users have not updated to menuinst v2 in their base env

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -16,6 +16,12 @@ for /f "delims=" %%i in (%RECIPE_DIR%\spyder-menu.json) do (
     echo !s:__PKG_MAJOR_VER__=%PKG_MAJOR_VER%!>> %MENU_DIR%\spyder-menu.json
 )
 
+for /f "delims=" %%i in (%RECIPE_DIR%\spyder-menu-v1.json) do (
+    set s=%%i
+    set s=!s:__PKG_VERSION__=%PKG_VERSION%!
+    echo !s:__PKG_MAJOR_VER__=%PKG_MAJOR_VER%!>> %MENU_DIR%\spyder-menu-v1.json.bak
+)
+
 del %SCRIPTS%\spyder_win_post_install.py
 del %SCRIPTS%\spyder.bat
 del %SCRIPTS%\spyder

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -3,25 +3,40 @@ setlocal ENABLEDELAYEDEXPANSION
 
 set menudir=%PREFIX%\Menu
 set menu=%menudir%\spyder-menu.json
+set logfile=%PREFIX%\.messages.txt
 
-call :conda_based
+rem  Check for conda-based install
+if exist "%menudir%\conda-based-app" (
+    rem  Abridge shortcut name
+    call :patch " ^({{ ENV_NAME }}^)="
 
-call :menuinst_ver || goto :exit
+    rem  Nothing more to do for conda-based install
+    goto :exit
+)
 
-call :base_env
+rem  Check for CONDA_PYTHON_EXE
+if not exist "%conda_python_exe%" (
+    rem  CONDA_PYTHON_EXE environment variable does not exist.
+    rem  v1 type shortcuts will not work
+    goto :base_env
+)
+
+rem  Check menuinst version
+for /F "tokens=*" %%i in (
+    '%conda_python_exe% -c "from importlib.metadata import version; from packaging.version import parse; print(parse(version('menuinst')) < parse('2'))"'
+) do (
+    if "%%~i"=="True" call :use_menu_v1
+)
+
+:base_env
+    if exist "%PREFIX%\condabin\" if exist "%PREFIX%\envs\" (
+        rem  Installed in a base environment, use distribution name
+        call :patch "ENV_NAME=DISTRIBUTION_NAME"
+    )
+    goto :exit
 
 :exit
     exit /b %errorlevel%
-
-:conda_based
-    if exist "%menudir%\conda-based-app" (
-        :: Installed in installer environment, abridge shortcut name
-        call :patch " ^({{ ENV_NAME }}^)="
-
-        :: Nothing more to do for conda-based install
-        goto :exit
-    )
-    goto :eof
 
 :patch
     set tmpmenu=%menudir%\spyder-menu-tmp.json
@@ -33,26 +48,11 @@ call :base_env
     move /y "%tmpmenu%" "%menu%"
     goto :eof
 
-:menuinst_ver
-    :: How to robustly call the base environment python?
-    for /F "tokens=*" %%i in (
-        '%conda_python_exe% -c "from importlib.metadata import version; from packaging.version import parse; print(parse(version('menuinst')) < parse('2'))"'
-    ) do (
-        set isv1=%%~i
-    )
-    if "%isv1%"=="True" (
-        copy /y "%menudir%\spyder-menu-v1.json.bak" "%menu%"
+:use_menu_v1
+    copy /y "%menudir%\spyder-menu-v1.json.bak" "%menu%"
 
-        :: Notify user
-        echo. >> %PREFIX%\.messages.txt
-        echo Warning! Using menuinst v1.>> %PREFIX%\.messages.txt
-        echo Please update to menuinst v2 in the base environment and reinstall Spyder>> %PREFIX%\.messages.txt
-    )
-    goto :eof
-
-:base_env
-    if exist "%PREFIX%\condabin\" if exist "%PREFIX%\envs\" (
-        :: Installed in a base environment, use distribution name
-        call :patch "ENV_NAME=DISTRIBUTION_NAME"
-    )
+    rem  Notify user
+    echo. >> %logfile%
+    echo Warning: Using menuinst v1 >> %logfile%
+    echo Please update to menuinst v2 in the base environment and reinstall Spyder >> %logfile%
     goto :eof

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -2,22 +2,28 @@
 setlocal ENABLEDELAYEDEXPANSION
 
 set menudir=%PREFIX%\Menu
+set menu=%menudir%\spyder-menu.json
 
-if exist "%menudir%\conda-based-app" (
-    :: Installed in installer environment, abridge shortcut name
-    call :patch " ^({{ ENV_NAME }}^)="
-)
+call :conda_based
 
-if exist "%PREFIX%\condabin\" if exist "%PREFIX%\envs\" (
-    :: Installed in a base environment, use distribution name
-    call :patch "ENV_NAME=DISTRIBUTION_NAME"
-)
+call :menuinst_ver || goto :exit
+
+call :base_env
 
 :exit
-exit /b %errorlevel%
+    exit /b %errorlevel%
+
+:conda_based
+    if exist "%menudir%\conda-based-app" (
+        :: Installed in installer environment, abridge shortcut name
+        call :patch " ^({{ ENV_NAME }}^)="
+
+        :: Nothing more to do for conda-based install
+        goto :exit
+    )
+    goto :eof
 
 :patch
-    set menu=%menudir%\spyder-menu.json
     set tmpmenu=%menudir%\spyder-menu-tmp.json
     set findreplace=%~1
     for /f "delims=" %%a in (%menu%) do (
@@ -25,4 +31,31 @@ exit /b %errorlevel%
         echo !s:%findreplace%!>> "%tmpmenu%"
     )
     move /y "%tmpmenu%" "%menu%"
-    goto :exit
+    goto :eof
+
+:menuinst_ver
+    :: How to robustly call the base environment python?
+    for /F "tokens=*" %%i in (
+        '%conda_python_exe% -c "from importlib.metadata import version; from packaging.version import parse; print(parse(version('menuinst')) < parse('2'))"'
+    ) do (
+        set isv1=%%~i
+    )
+    if "%isv1%"=="True" (
+        :: Rename v2 json
+        move /y "%menu%" "%menu%.bak"
+
+        :: Rename v1 json
+        set menu=%menudir%\spyder-menu-v1.json
+        move /y "%menu%.bak" "%menu%"
+
+        :: Notify user
+        echo Warning! Using menuinst v1. Please update to menuinst v2 in the base environment and reinstall Spyder>> %PREFIX%\.messages.txt
+    )
+    goto :eof
+
+:base_env
+    if exist "%PREFIX%\condabin\" if exist "%PREFIX%\envs\" (
+        :: Installed in a base environment, use distribution name
+        call :patch "ENV_NAME=DISTRIBUTION_NAME"
+    )
+    goto :eof

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -41,15 +41,12 @@ call :base_env
         set isv1=%%~i
     )
     if "%isv1%"=="True" (
-        :: Rename v2 json
-        move /y "%menu%" "%menu%.bak"
-
-        :: Rename v1 json
-        set menu=%menudir%\spyder-menu-v1.json
-        move /y "%menu%.bak" "%menu%"
+        copy /y "%menudir%\spyder-menu-v1.json.bak" "%menu%"
 
         :: Notify user
-        echo Warning! Using menuinst v1. Please update to menuinst v2 in the base environment and reinstall Spyder>> %PREFIX%\.messages.txt
+        echo. >> %PREFIX%\.messages.txt
+        echo Warning! Using menuinst v1.>> %PREFIX%\.messages.txt
+        echo Please update to menuinst v2 in the base environment and reinstall Spyder>> %PREFIX%\.messages.txt
     )
     goto :eof
 

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -23,7 +23,7 @@ if not exist "%conda_python_exe%" (
 
 rem  Check menuinst version
 for /F "tokens=*" %%i in (
-    '%conda_python_exe% -c "from importlib.metadata import version; from packaging.version import parse; print(parse(version('menuinst')) < parse('2'))"'
+    '%conda_python_exe% -c "import menuinst; print(int(menuinst.__version__[0]) < 2)"'
 ) do (
     if "%%~i"=="True" call :use_menu_v1
 )

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e
 
-[[ $(sed --version 2>/dev/null) ]] && opts=("-i" "-E") || opts=("-i" "" "-E")
+[[ $(sed --version 2>/dev/null) ]] && opts=("-i" "-E") || opts=("-i" "''" "-E")
 menu="${PREFIX}/Menu/spyder-menu.json"
 
 if [[ -f "${PREFIX}/Menu/conda-based-app" ]]; then
     # Installed in installer environment, abridge shortcut name
-    sed "${opts[@]}" "s/ \(\{\{ ENV_NAME \}\}\)//g" $menu
+    sed ${opts[@]} "s/ \(\{\{ ENV_NAME \}\}\)//g" $menu
 elif [[ -d "${PREFIX}/condabin" && -d "${PREFIX}/envs" ]]; then
     # Installed in a base environment, use distribution name
-    sed "${opts[@]}" "s/ENV_NAME/DISTRIBUTION_NAME/g" $menu
+    sed ${opts[@]} "s/ENV_NAME/DISTRIBUTION_NAME/g" $menu
 fi

--- a/recipe/spyder-menu-v1.json
+++ b/recipe/spyder-menu-v1.json
@@ -3,7 +3,7 @@
     "menu_items":
     [
         {
-            "name": "Spyder __PKG_MAJOR_VER__ (${ENV_NAME})",
+            "name": "Spyder __PKG_MAJOR_VER__",
             "pywscript": "${PYTHON_SCRIPTS}/spyder-script.py",
             "workdir": "${PERSONALDIR}/Python Scripts",
             "icon": "${MENU_DIR}/spyder.ico"

--- a/recipe/spyder-menu-v1.json
+++ b/recipe/spyder-menu-v1.json
@@ -1,0 +1,12 @@
+{
+    "menu_name": "${DISTRIBUTION_NAME} spyder",
+    "menu_items":
+    [
+        {
+            "name": "Spyder __PKG_MAJOR_VER__ (${ENV_NAME})",
+            "pywscript": "${PYTHON_SCRIPTS}/spyder-script.py",
+            "workdir": "${PERSONALDIR}/Python Scripts",
+            "icon": "${MENU_DIR}/spyder.ico"
+        }
+    ]
+}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes: spyder-ide/spyder#21855

<!--
Please add any other relevant info below:
-->

This change _only applies to Windows_. macOS and Linux shortcuts are unaffected.

If the version of `menuinst` is `<2`, then the v2 spec file is replaced with the v1 spec file. The Windows post link script relies on the `CONDA_PYTHON_EXE` environment variable to determine the `menuinst` version. If `CONDA_PYTHON_EXE` does not exist, then no action is taken with respect to the v1 spec file, and the v2 spec file remains.

The most likely scenario where `CONDA_PYTHON_EXE` is not available is with the use of standalone conda executables (e.g. Micromamba). Note that the existing v1 spec file in Spyder's 5.x branch is broken if it is created when installing Spyder with Micromamba. This is because there is no base reference environment. The shortcut is created, but does not work. With this PR, shortcuts are not created under these circumstances: it is better to not create a shortcut than to create a broken one.