### PR TITLE
Use v1 json spec for Windows menu entry and do not create shortcut on Posix for `menuinst` less than 2.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - osx-zmq.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx and arm64 and py < 39]
   entry_points:
     - spyder = spyder.app.start:main

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -28,9 +28,9 @@ if not exist "%conda_python_exe%" (
 
 rem  Check menuinst version
 for /F "tokens=*" %%i in (
-    '%conda_python_exe% -c "import menuinst; print(int(menuinst.__version__[0]) < 2)"'
+    '%conda_python_exe% -c "import menuinst; print(menuinst.__version__)"'
 ) do (
-    if "%%~i"=="True" call :use_menu_v1
+    if "%%~i" lss "2.1.2" call :use_menu_v1
 )
 
 :exit
@@ -52,5 +52,5 @@ for /F "tokens=*" %%i in (
     rem  Notify user
     echo. >> %logfile%
     echo Warning: Using menuinst v1 >> %logfile%
-    echo Please update to menuinst v2 in the base environment and reinstall Spyder >> %logfile%
+    echo Please update to menuinst >=2.1.2 in the base environment and reinstall Spyder >> %logfile%
     goto :eof

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -8,3 +8,11 @@ if [[ -f "${PREFIX}/Menu/conda-based-app" ]]; then
     # Installed in installer environment, abridge shortcut name
     sed "${opts[@]}" "s/ \(\{\{ ENV_NAME \}\}\)//g" $menu
 fi
+
+# Do not create shortcut for menuinst version <2.1.2
+menuinst_version=$($CONDA_PYTHON_EXE -c "import menuinst; print(menuinst.__version__)")
+if [[ "$menuinst_version" < "2.1.2" ]]; then
+    mv -f ${menu} ${menu}.bak
+    echo "Warning: Spyder shortcut will not be created." >> ${PREFIX}/.message.txt
+    echo "Please update to menuinst >=2.1.2 in the base environment and reinstall Spyder." >> ${PREFIX}/.message.txt
+fi


### PR DESCRIPTION
Windows:
* `menuinst` <2.1.2 will use v1 json file
* `menuinst` >=2.1.2 will use v2 json file

macOS & Linux:
* `menuinst` <2.1.2, no shortcut created.
* `menuinst` >=2.1.2 will use v2 json file

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes: spyder-ide/spyder#22428
<!--
Please add any other relevant info below:
-->
