### PR TITLE
Fix issue where retrieving menuinst version resulted in an error

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - osx-zmq.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx and arm64 and py < 39]
   entry_points:
     - spyder = spyder.app.start:main

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -7,10 +7,13 @@ menu="${PREFIX}/Menu/spyder-menu.json"
 if [[ -f "${PREFIX}/Menu/conda-based-app" ]]; then
     # Installed in installer environment, abridge shortcut name
     sed "${opts[@]}" "s/ \(\{\{ ENV_NAME \}\}\)//g" $menu
+
+    # Nothing more to do for conda-based-installers
+    exit
 fi
 
 # Do not create shortcut for menuinst version <2.1.2
-menuinst_version=$($CONDA_PYTHON_EXE -c "import menuinst; print(menuinst.__version__)")
+menuinst_version=$($CONDA_PYTHON_EXE -c "import menuinst; print(menuinst.__version__)" 2>/dev/null || echo "0.0.0")
 if [[ "$menuinst_version" < "2.1.2" ]]; then
     mv -f ${menu} ${menu}.bak
     echo "Warning: Spyder shortcut will not be created." >> ${PREFIX}/.message.txt


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes: spyder-ide/spyder#22566
Fixes: spyder-ide/spyder#22565
<!--
Please add any other relevant info below:
-->
* Do not check `menuinst` version for conda-based apps. This is not necessary and circumvents any inconsistencies with `CONDA_PYTHON_EXE` introduced by `constructor` at install time.
* Do not create shortcut if there is an error retrieving the `menuinst` version. This should catch any error due to `CONDA_PYTHON_EXE` or if `menuinst` is not installed.