### PR TITLE
Update application system identifiers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - osx-zmq.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [osx and arm64 and py < 39]
   entry_points:
     - spyder = spyder.app.start:main

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -7,10 +7,14 @@ menu="${PREFIX}/Menu/spyder-menu.json"
 if [[ -f "${PREFIX}/Menu/conda-based-app" ]]; then
     # Installed in installer environment, abridge shortcut name
     sed "${opts[@]}" "s/ \(\{\{ ENV_NAME \}\}\)//g" $menu
+    sed "${opts[@]}" "s/-__CFBID_ENV__//g" $menu
 
     # Nothing more to do for conda-based-installers
     exit
 fi
+
+env_name=$(basename ${PREFIX//_/-})
+sed "${opts[@]}" "s/__CFBID_ENV__/${env_name}/g" $menu
 
 # Do not create shortcut for menuinst version <2.1.2
 menuinst_version=$($CONDA_PYTHON_EXE -c "import menuinst; print(menuinst.__version__)" 2>/dev/null || echo "0.0.0")

--- a/recipe/spyder-menu.json
+++ b/recipe/spyder-menu.json
@@ -16,7 +16,7 @@
             "platforms": {
                 "win": {
                     "desktop": true,
-                    "app_user_model_id": "spyder.Spyder",
+                    "app_user_model_id": "spyder-ide.Spyder-__PKG_MAJOR_VER__.{{ ENV_NAME }}",
                     "command": ["{{ PREFIX }}/Scripts/spyder.exe", "%*"],
                     "file_extensions": [
                         ".enaml",
@@ -33,7 +33,7 @@
                         "Science"
                     ],
                     "command": ["{{ PREFIX }}/bin/spyder", "%F"],
-                    "StartupWMClass": "Spyder",
+                    "StartupWMClass": "Spyder-__PKG_MAJOR_VER__.{{ ENV_NAME }}",
                     "MimeType": [
                         "text/x-python"
                     ]
@@ -45,7 +45,7 @@
                         "{{ PREFIX }}/bin/python": "{{ MENU_ITEM_LOCATION }}/Contents/MacOS/python"
                     },
                     "CFBundleName": "Spyder __PKG_MAJOR_VER__",
-                    "CFBundleIdentifier": "org.spyder-ide.Spyder",
+                    "CFBundleIdentifier": "org.spyder-ide.Spyder-__PKG_MAJOR_VER__-__CFBID_ENV__",
                     "CFBundleVersion": "__PKG_VERSION__",
                     "CFBundleDocumentTypes": [
                         {


### PR DESCRIPTION
Change `app_user_model_id`, `StartupWMClass`, and `CFBundleIdentifier` to include Spyder major version and (possibly) environment name. This should ensure uniqueness if multiple instances of Spyder are installed. Note `CFBundleIdentifier` cannot contain underscores.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
