### PR TITLE
Set SingleMainWindow to true for Linux.

### DIFF
--- a/recipe/spyder-menu.json
+++ b/recipe/spyder-menu.json
@@ -34,6 +34,7 @@
                     ],
                     "command": ["{{ PREFIX }}/bin/spyder", "%F"],
                     "StartupWMClass": "Spyder-__PKG_MAJOR_VER__.{{ ENV_NAME }}",
+                    "SingleMainWindow": true,
                     "MimeType": [
                         "text/x-python"
                     ]


### PR DESCRIPTION
Enforces single instance on Linux.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This feature is now incorporated into `menuinst=2.2.0`.
I'm not certain yet whether including it here will raise an error for `menuinst=2.1.2` or just be ineffective.