### PR TITLE
Create spyder-base package that does not depend on pyqt

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-spyder-green.svg)](https://anaconda.org/conda-forge/spyder) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/spyder.svg)](https://anaconda.org/conda-forge/spyder) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/spyder.svg)](https://anaconda.org/conda-forge/spyder) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/spyder.svg)](https://anaconda.org/conda-forge/spyder) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-spyder--base-green.svg)](https://anaconda.org/conda-forge/spyder-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/spyder-base.svg)](https://anaconda.org/conda-forge/spyder-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/spyder-base.svg)](https://anaconda.org/conda-forge/spyder-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/spyder-base.svg)](https://anaconda.org/conda-forge/spyder-base) |
 
 Installing spyder
 =================
@@ -113,16 +114,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `spyder` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `spyder, spyder-base` can be installed with `conda`:
 
 ```
-conda install spyder
+conda install spyder spyder-base
 ```
 
 or with `mamba`:
 
 ```
-mamba install spyder
+mamba install spyder spyder-base
 ```
 
 It is possible to list all of the versions of `spyder` available on your platform with `conda`:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,6 @@
 setlocal ENABLEDELAYEDEXPANSION
 
+set SPYDER_QT_BINDING=conda-forge
 %PYTHON% -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export SPYDER_QT_BINDING=conda-forge
 $PYTHON -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 rm -rf $PREFIX/man

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,9 @@
 {% set version = "6.0.4" %}
 {% set python_min = "3.8" %}
+{% set build = 1 %}
 
 package:
-  name: spyder
+  name: spyder-base
   version: {{ version }}
 
 source:
@@ -13,13 +14,13 @@ source:
     - osx-zmq.patch
 
 build:
-  number: 0
+  number: {{ build }}
   entry_points:
     - spyder = spyder.app.start:main
   osx_is_app: true
   # https://github.com/conda/conda-build/issues/5385
-  noarch: python  # [not win]
-  string: "osx_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"  # [osx]
+  noarch: python  # [unix]
+  string: "osx_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"    # [osx]
   string: "linux_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"  # [linux]
 
 requirements:
@@ -58,16 +59,14 @@ requirements:
     - parso >=0.7.0,<0.9.0
     - pexpect >=4.4.0
     - pickleshare >=0.4
+    - psutil >=5.3
     # This is here to work around a bug in mamba
     - ptyprocess >=0.5  # [win]
-    - psutil >=5.3
     - pygithub >=2.3.0
     - pygments >=2.0
     - pylint >=3.1,<4
     - pylint-venv >=3.0.2
     - pyls-spyder >=0.4.0
-    - pyqt >=5.15,<5.16
-    - pyqtwebengine >=5.15,<5.16
     - python.app  # [osx]
     - python-lsp-black >=2.0.0,<3.0.0
     - python-lsp-server >=1.12.0,<1.13.0
@@ -77,7 +76,7 @@ requirements:
     - qdarkstyle >=3.2.0,<3.3.0
     - qstylizer >=0.2.2
     - qtawesome >=1.3.1,<1.4.0
-    - qtconsole >=5.6.1,<5.7.0
+    - qtconsole-base >=5.6.1,<5.7.0
     - qtpy >=2.4.0
     - rtree >=0.9.7
     - setuptools >=49.6.0
@@ -93,16 +92,14 @@ requirements:
     - __osx    # [osx]
   run_constrained:
     - menuinst >=2.1.2
+    - spyder =={{ version }}=*{{ build }}
 
 test:
   requires:
-    - python {{ python_min }}  # [unix]
     - pip
   commands:
-    - USER=test spyder -h  # [unix]
-    - spyder -h  # [win]
-    # Pip fails when running but the package is installed correctly
-    - python -m pip check  # [not aarch64]
+    - spyder -h
+    - python -m pip check
   imports:
     - spyder
 
@@ -111,6 +108,26 @@ app:
   icon: spyder.png
   summary: The Scientific Python Development Environment
   type: desk
+
+outputs:
+  - name: spyder-base
+  - name: spyder
+    build:
+      noarch: python
+    requirements:
+      run:
+        - spyder-base =={{ version }}=*{{ build }}
+        - pyqt >=5.15,<5.16
+        - pyqtwebengine >=5.15,<5.16
+        - qtconsole >=5.6.1,<5.7.0
+    test:
+      requires:
+        - pip
+      commands:
+        - spyder -h
+        - python -m pip check
+      imports:
+        - spyder
 
 about:
   home: https://www.spyder-ide.org/
@@ -136,6 +153,7 @@ about:
   dev_url: https://github.com/spyder-ide/spyder
 
 extra:
+  feedstock-name: spyder
   recipe-maintainers:
     - ccordoba12
     - dalthviz


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #175
Fixes #178
<!--
Please add any other relevant info below:
-->

This PR's workflows will fail until the changes in spyder-ide/spyder#23141 are propagated to PyPi.

spyder-ide/spyder#23141 can be merged anytime, since it should only impact installer builds for PRs. This PR should be merged some time after spyder-ide/spyder#23141 is merged, but immediately following upload of the PyPi package prior to a release or release candidate. Once this PR is merged, the remaining release steps can proceed.

### Summary

This PR intends to create two packages from one feedstock.
* `spyder-base`: contains the `spyder` source code and specifies all of `spyder`'s dependencies *except* any direct or indirect dependence on `pyqt`.
* `spyder`: only specifies `spyder`'s direct and indirect dependencies on `pyqt`.

The intention is to provide a way for users to use `pyside6` rather than `pyqt`, e.g.
```
conda install spyder-base pyside6
```
Installing `spyder` in the standard fashion will still yield a `pyqt`-based install.
```
conda install spyder
```

### Notes

`spyder-base` was chosen as the "parent" package and `spyder` as the "subpackage" because  the post-link scripts will only be included with the parent package and not the subpackage. Spyder's shortcut (via `menuinst`) is customized conditioned on the install environment, not target platform, and therefore can only use the post-link mechanism to achieve this. `spyder-base` must run the post-link scripts at install time, not `spyder`, in order to provide the shortcut in the case of using `pyside6` rather than `pyqt`. If the Spyder shortcut did not require the post-link mechanism, then we could make `spyder` the parent package and `spyder-base` the subpackage.

`python {{ python_min }}  # [unix]` was removed and other selectors were merged in the test environment(s) because it appears that they are not needed. The `python` spec is not needed for the tests to pass on macOS or Linux and *cannot* be present on Windows, else the tests fail (the test environment cannot be solved). Removing `python` and merging selectors in the `spyder` noarch package also helps ensure the build hash is the same across all platforms.

### Concerns

I do not know which application Anaconda Navigator will provide: `spyder-base`, `spyder`, or both. The `app` section is not allowed in an item of the `outputs` section, i.e. the `spyder` package, so we cannot explicitly use it for the subpackage and remove it from the parent package. I suspect that Anaconda Navigator will recognize both packages as applications because the `app` header appears in the rendered `meta.yaml` for both packages, and this could be confusing. It may also be possible that Anaconda Navigator will only recognize the parent package as an application (i.e. `spyder-base`), which would be the worst outcome since this would not run without explicitly installing the remaining dependencies.