### PR TITLE
Ensure registry command argument is double-quoted on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - osx-zmq.patch
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - spyder = spyder.app.start:main
   osx_is_app: true

--- a/recipe/spyder-menu-win.json
+++ b/recipe/spyder-menu-win.json
@@ -14,7 +14,7 @@
             "terminal": false,
             "desktop": true,
             "app_user_model_id": "spyder-ide.Spyder-__PKG_MAJOR_VER__.{{ ENV_NAME }}",
-            "command": ["{{ PREFIX }}/Scripts/spyder.exe", "%*"],
+            "command": ["{{ PREFIX }}/Scripts/spyder.exe", "%1 "],
             "file_extensions": [
                 ".enaml",
                 ".ipy",


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes spyder-ide/spyder#22844
<!--
Please add any other relevant info below:
-->
`"%*"` appears to be ineffective on Windows, and `menuinst` strips explicit quotes, e.g. `"\"%1\""`.

Upon investigating `menuinst` source code (https://github.com/conda/menuinst/blob/903ae24739b48748cb5ad60c2bf3ac1c1febfbd6/menuinst/utils.py#L159-L171), a workaround is to add a space at the end of the argument.

This ensures that the `"%1"` is double-quoted in the registry command, allowing files/paths with spaces to be handled correctly.

See conda/menuinst#290