### PR TITLE
RC version of PR 203

### DIFF
--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -8,5 +8,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+python_min:
+- '3.9'
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -8,5 +8,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+python_min:
+- '3.9'
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -8,5 +8,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+python_min:
+- '3.9'
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -8,5 +8,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+python_min:
+- '3.9'
 target_platform:
 - win-64

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-spyder-green.svg)](https://anaconda.org/conda-forge/spyder) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/spyder.svg)](https://anaconda.org/conda-forge/spyder) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/spyder.svg)](https://anaconda.org/conda-forge/spyder) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/spyder.svg)](https://anaconda.org/conda-forge/spyder) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-spyder--base-green.svg)](https://anaconda.org/conda-forge/spyder-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/spyder-base.svg)](https://anaconda.org/conda-forge/spyder-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/spyder-base.svg)](https://anaconda.org/conda-forge/spyder-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/spyder-base.svg)](https://anaconda.org/conda-forge/spyder-base) |
 
 Installing spyder
 =================
@@ -113,16 +114,16 @@ conda config --add channels conda-forge/label/spyder_rc
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge/label/spyder_rc` channel has been enabled, `spyder` can be installed with `conda`:
+Once the `conda-forge/label/spyder_rc` channel has been enabled, `spyder, spyder-base` can be installed with `conda`:
 
 ```
-conda install spyder
+conda install spyder spyder-base
 ```
 
 or with `mamba`:
 
 ```
-mamba install spyder
+mamba install spyder spyder-base
 ```
 
 It is possible to list all of the versions of `spyder` available on your platform with `conda`:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,6 @@
 setlocal ENABLEDELAYEDEXPANSION
 
+set SPYDER_QT_BINDING=conda-forge
 %PYTHON% -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export SPYDER_QT_BINDING=conda-forge
 $PYTHON -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 rm -rf $PREFIX/man

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,9 @@
 {% set version = "6.0.3rc2" %}
 {% set python_min = "3.8" %}
+{% set build = 1 %}
 
 package:
-  name: spyder
+  name: spyder-base
   version: {{ version }}
 
 source:
@@ -13,13 +14,13 @@ source:
     - osx-zmq.patch
 
 build:
-  number: 0
+  number: {{ build }}
   entry_points:
     - spyder = spyder.app.start:main
   osx_is_app: true
   # https://github.com/conda/conda-build/issues/5385
-  noarch: python  # [not win]
-  string: "osx_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"  # [osx]
+  noarch: python  # [unix]
+  string: "osx_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"    # [osx]
   string: "linux_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"  # [linux]
 
 requirements:
@@ -58,16 +59,14 @@ requirements:
     - parso >=0.7.0,<0.9.0
     - pexpect >=4.4.0
     - pickleshare >=0.4
+    - psutil >=5.3
     # This is here to work around a bug in mamba
     - ptyprocess >=0.5  # [win]
-    - psutil >=5.3
     - pygithub >=2.3.0
     - pygments >=2.0
     - pylint >=3.1,<4
     - pylint-venv >=3.0.2
     - pyls-spyder >=0.4.0
-    - pyqt >=5.15,<5.16
-    - pyqtwebengine >=5.15,<5.16
     - python.app  # [osx]
     - python-lsp-black >=2.0.0,<3.0.0
     - python-lsp-server >=1.12.0,<1.13.0
@@ -77,7 +76,7 @@ requirements:
     - qdarkstyle >=3.2.0,<3.3.0
     - qstylizer >=0.2.2
     - qtawesome >=1.3.1,<1.4.0
-    - qtconsole >=5.6.1,<5.7.0
+    - qtconsole-base >=5.6.1,<5.7.0
     - qtpy >=2.4.0
     - rtree >=0.9.7
     - setuptools >=49.6.0
@@ -93,16 +92,14 @@ requirements:
     - __osx    # [osx]
   run_constrained:
     - menuinst >=2.1.2
+    - spyder =={{ version }}=*{{ build }}
 
 test:
   requires:
-    - python {{ python_min }}  # [unix]
     - pip
   commands:
-    - USER=test spyder -h  # [unix]
-    - spyder -h  # [win]
-    # Pip fails when running but the package is installed correctly
-    - python -m pip check  # [not aarch64]
+    - spyder -h
+    - python -m pip check
   imports:
     - spyder
 
@@ -111,6 +108,26 @@ app:
   icon: spyder.png
   summary: The Scientific Python Development Environment
   type: desk
+
+outputs:
+  - name: spyder-base
+  - name: spyder
+    build:
+      noarch: python
+    requirements:
+      run:
+        - spyder-base =={{ version }}=*{{ build }}
+        - pyqt >=5.15,<5.16
+        - pyqtwebengine >=5.15,<5.16
+        - qtconsole >=5.6.1,<5.7.0
+    test:
+      requires:
+        - pip
+      commands:
+        - spyder -h
+        - python -m pip check
+      imports:
+        - spyder
 
 about:
   home: https://www.spyder-ide.org/
@@ -136,6 +153,7 @@ about:
   dev_url: https://github.com/spyder-ide/spyder
 
 extra:
+  feedstock-name: spyder
   recipe-maintainers:
     - ccordoba12
     - dalthviz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "6.0.3rc2" %}
+{% set version = "6.0.4rc1" %}
 {% set python_min = "3.8" %}
-{% set build = 1 %}
+{% set build = 0 %}
 
 package:
   name: spyder-base
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/s/spyder/spyder-{{ version }}.tar.gz
-  sha256: 258b08d53544505d69922342c3e7f964143d3d5be56de12c44c4a52152d7c09d
+  sha256: 33067a36dbb700ad666761f6918cd73fbf2a16a0f17d1c4db49afe20bb6e5165
   patches:
     # See spyder-ide/spyder#8316
     - osx-zmq.patch


### PR DESCRIPTION
See #203.

1. Release 6.0.4rc1 to PyPi
2. Update feedstock in this PR:
   * version: 6.0.4rc1
   * build: 0
   * sha256: _from PyPi_
3. Verify checks succeed
4. Merge this PR
5. Proceed with 6.0.4rc1 release to conda-forge and GitHub  