### PR TITLE
PR: Move `fcitx-qt5` dependency from spyder-base to spyder

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "6.0.5" %}
 {% set python_min = "3.8" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 package:
   name: spyder-base
@@ -50,7 +50,6 @@ requirements:
     - cloudpickle >=0.5.0
     - cookiecutter >=1.6.0
     - diff-match-patch >=20181111
-    - fcitx-qt5 >=1.2.7  # [linux]
     - fzf >=0.42.0
     - importlib-metadata >=4.6.0
     - intervaltree >=3.0.2
@@ -122,6 +121,7 @@ outputs:
     requirements:
       run:
         - spyder-base =={{ version }}=*{{ build }}
+        - fcitx-qt5 >=1.2.7  # [linux]
         - pyqt >=5.15,<5.16
         - pyqtwebengine >=5.15,<5.16
         - qtconsole >=5.6.1,<5.7.0


### PR DESCRIPTION
This was missed in #203.