### PR TITLE
Patch `site.py` in spyder-runtime environment to prevent using user site-packages

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,6 +6,12 @@ channel_targets:
 - conda-forge spyder_dev
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
 python_min:
 - '3.9'
 target_platform:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -8,6 +8,12 @@ channel_targets:
 - conda-forge spyder_dev
 macos_machine:
 - x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
 python_min:
 - '3.9'
 target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "6.1.0a4" %}
 {% set python_min = "3.9" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: spyder-base

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -12,38 +12,56 @@ del %scriptsdir%\spyder-script.py
 
 rem  Check for conda-based install
 if exist "%menudir%\conda-based-app" (
-    rem  Abridge shortcut name
-    call :patch " ^({{ ENV_NAME }}^)=" %menu%
-
+    call :conda_based_install
     rem  Nothing more to do for conda-based install
     goto :exit
 )
 
-rem  Check for CONDA_PYTHON_EXE
-if not exist "%conda_python_exe%" (
-    rem  CONDA_PYTHON_EXE environment variable does not exist.
-    rem  v1 type shortcuts will not work
-    goto :exit
-)
-
-rem  Check menuinst version
-for /F "tokens=*" %%i in (
-    '%conda_python_exe% -c "import menuinst; print(menuinst.__version__)"'
-) do (
-    if "%%~i" lss "2.1.2" call :use_menu_v1
-)
+call :not_conda_based_install
 
 :exit
     exit /b %errorlevel%
 
+:conda_based_install
+    rem  Abridge shortcut name
+    call :patch " ^({{ ENV_NAME }}^)=" %menu%
+
+    rem  Prevent using user site-packages
+    rem  See https://github.com/spyder-ide/spyder/issues/24773
+    set site=%PREFIX%\envs\spyder-runtime\Lib\site.py
+    set site_tmp=%PREFIX%\envs\spyder-runtime\Lib\site.py.bak
+    (for /f "delims=" %%i in ('type "%site%" ^| findstr /n "^"') do (
+        set "s=%%i"
+        set "s=!s:*:=!"
+        if "!s!"=="ENABLE_USER_SITE = None" set s=!s:None=False!
+        echo.!s!
+    )) > %site_tmp% && move /y %site_tmp% %site% >nul
+
+    goto :eof
+
+:not_conda_based_install
+    rem  Check for CONDA_PYTHON_EXE
+    if not exist "%conda_python_exe%" (
+        rem  CONDA_PYTHON_EXE environment variable does not exist.
+        rem  v1 type shortcuts will not work
+        goto :exit
+    )
+
+    rem  Check menuinst version
+    for /F "tokens=*" %%i in (
+        '%conda_python_exe% -c "import menuinst; print(menuinst.__version__)"'
+    ) do (
+        if "%%~i" lss "2.1.2" call :use_menu_v1
+    )
+
 :patch
     set tmpmenu=%menudir%\tmp.json
     set findreplace=%~1
-    for /f "delims=" %%a in (%~2) do (
-        set s=%%a
-        echo !s:%findreplace%!>> "%tmpmenu%"
-    )
-    move /y "%tmpmenu%" "%~2"
+    (for /f "delims=" %%a in ('type "%~2" ^| findstr /n "^"') do (
+        set "s=%%a"
+        set "s=!s:*:=!"
+        echo !s:%findreplace%!
+    )) > "%tmpmenu%" && move /y "%tmpmenu%" "%~2" >nul
     goto :eof
 
 :use_menu_v1

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -9,6 +9,11 @@ if [[ -f "${PREFIX}/Menu/conda-based-app" ]]; then
     sed "${opts[@]}" "s/ \(\{\{ ENV_NAME \}\}\)//g" $menu
     sed "${opts[@]}" "s/-__CFBID_ENV__//g" $menu
 
+    # Prevent using user site-packages
+    # See https://github.com/spyder-ide/spyder/issues/24773
+    site=$(find ${PREFIX}/lib/python* -name "site.py")
+    sed "${opts[@]}" 's/^ENABLE_USER_SITE = None/ENABLE_USER_SITE = False/g' "${site}"
+
     # Nothing more to do for conda-based-installers
     exit
 fi


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
To prevent user site-packages from being used in Spyder's installer runtime environment, the `site.py` module is patched via `post-link.[sh|bat]` scripts.

`PYTHONNOUSERSITE=1` or the `-s` flag are mechanisms that achieve the same thing, however, neither of these options is practical with `menuinst` on all platforms.

Fixes https://github.com/spyder-ide/spyder/issues/24773