### PR TITLE
Add an uninstall shortcut for our macOS and Linux installers

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-13
+    vmImage: macOS-15
   strategy:
     matrix:
       osx_64_:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -20,10 +20,10 @@ jobs:
         CONFIG: win_64_python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: win_64_python3.12.____cpython
-      win_64_python3.9.____cpython:
-        CONFIG: win_64_python3.9.____cpython
+      win_64_python3.13.____cp313:
+        CONFIG: win_64_python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: win_64_python3.9.____cpython
+        SHORT_CONFIG: win_64_python3.13.____cp313
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,7 +6,13 @@ channel_targets:
 - conda-forge spyder_dev
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
 python_min:
-- '3.9'
+- '3.10'
 target_platform:
 - linux-64

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -8,7 +8,13 @@ channel_targets:
 - conda-forge spyder_dev
 macos_machine:
 - x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
 python_min:
-- '3.9'
+- '3.10'
 target_platform:
 - osx-64

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -9,6 +9,6 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 python_min:
-- '3.9'
+- '3.10'
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -9,6 +9,6 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 python_min:
-- '3.9'
+- '3.10'
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -9,6 +9,6 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 python_min:
-- '3.9'
+- '3.10'
 target_platform:
 - win-64

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -7,8 +7,8 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.13.* *_cp313
 python_min:
-- '3.9'
+- '3.10'
 target_platform:
 - win-64

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_python3.9.____cpython</td>
+              <td>win_64_python3.13.____cp313</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3589&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spyder-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spyder-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,7 +11,11 @@ rm -rf $SP_DIR/Sphinx-*
 mkdir -p "${PREFIX}/Menu"
 
 # Copy menu.json template, replacing version
-sed -e "s/__PKG_VERSION__/${PKG_VERSION}/g" -e "s/__PKG_MAJOR_VER__/${PKG_VERSION%%.*}/g" "${RECIPE_DIR}/spyder-menu-unix.json" > "${PREFIX}/Menu/spyder-menu.json"
+function replace(){
+    sed -e "s/__PKG_VERSION__/${PKG_VERSION}/g" -e "s/__PKG_MAJOR_VER__/${PKG_VERSION%%.*}/g" "$1" > "$2"
+}
+replace "${RECIPE_DIR}/spyder-menu-unix.json" "${PREFIX}/Menu/spyder-menu.json"
+replace "${RECIPE_DIR}/spyder-uninstall-menu.json" "${PREFIX}/Menu/spyder-uninstall-menu.json"
 
 # Copy application icons
 if [[ $OSTYPE == "darwin"* ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "6.1.0a4" %}
 {% set python_min = "3.9" %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 package:
   name: spyder-base

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -3,9 +3,12 @@ set -e
 
 [[ $(sed --version 2>/dev/null) ]] && opts=("-i" "-E") || opts=("-i" "" "-E")
 menu="${PREFIX}/Menu/spyder-menu.json"
+umenu="${PREFIX}/Menu/spyder-uninstall-menu.json"
 
 if [[ -f "${PREFIX}/Menu/conda-based-app" ]]; then
-    # Installed in installer environment, abridge shortcut name
+    # Installed using our installer...
+
+    # Abridge shortcut name
     sed "${opts[@]}" "s/ \(\{\{ ENV_NAME \}\}\)//g" $menu
     sed "${opts[@]}" "s/-__CFBID_ENV__//g" $menu
 
@@ -18,6 +21,12 @@ if [[ -f "${PREFIX}/Menu/conda-based-app" ]]; then
     exit
 fi
 
+# Not using our installer...
+
+# Do not create uninstall shortcut
+rm -f $umenu || true
+
+# Use environment name in shortcut name
 env_name=$(basename ${PREFIX//_/-})
 sed "${opts[@]}" "s/__CFBID_ENV__/${env_name}/g" $menu
 

--- a/recipe/spyder-uninstall-menu.json
+++ b/recipe/spyder-uninstall-menu.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "$id": "https://schemas.conda.io/menuinst-1.schema.json",
+    "menu_name": "{{ DISTRIBUTION_NAME }} spyder uninstaller",
+    "menu_items": [
+        {
+            "name": "Spyder __PKG_MAJOR_VER__ Uninstaller",
+            "description": "Spyder Uninstaller",
+            "icon": "{{ MENU_DIR }}/spyder.{{ ICON_EXT }}",
+            "activate": false,
+            "terminal": true,
+            "command": ["{{ BASE_PREFIX }}/uninstall-spyder.sh"],
+            "platforms": {
+                "linux": {
+                    "Categories": [
+                        "Development",
+                        "Science"
+                    ],
+                    "StartupWMClass": "Spyder-__PKG_MAJOR_VER__-Uninstaller",
+                    "SingleMainWindow": true
+                },
+                "osx": {
+                    "CFBundleName": "Spyder __PKG_MAJOR_VER__ Uninstaller",
+                    "CFBundleIdentifier": "org.spyder-ide.Spyder-__PKG_MAJOR_VER__-Uninstaller",
+                    "CFBundleVersion": "__PKG_VERSION__"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This adds an uninstall shortcut for our installers on macOS and Linux.
For standard conda installs, the uninstaller shortcut menu is removed so that the shortcut is not created.

Closing this PR.
The uninstall shortcut is only for Spyder's installer, not general conda package installation. Therefore the json file must be removed from the Menu directory by the post-link script when not installed with Spyder's installers. However, menuinst raises an error because it cannot find the json file it expects to be there. The solution is that the menu file must be _added_ and run by the installer and not included with Spyder's conda package.