### PR TITLE
Set system preference to always show scroll bars on macOS for Spyder's application bundle ID

### DIFF
--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -25,6 +25,7 @@ sed "${opts[@]}" "s/__CFBID_ENV__/${env_name}/g" $menu
 menuinst_min_version="2.1.2"
 if [[ "$OSTYPE" == "darwin"* ]]; then
     menuinst_min_version="2.4.0"
+    cfbundleid=$(grep '"CFBundleIdentifier"' $menu | sed -E 's/.*"CFBundleIdentifier": *"([^"]+)".*/\1/')
 fi
 menuinst_version=$($CONDA_PYTHON_EXE -c "import menuinst; print(menuinst.__version__)" 2>/dev/null || echo "0.0.0")
 last_version=$(echo -e "${menuinst_version}\n${menuinst_min_version}" | sort -V | tail -n1)
@@ -32,4 +33,11 @@ if [[ "${menuinst_version}" != "${last_version}" ]]; then
     mv -f ${menu} ${menu}.bak
     echo "Warning: Spyder shortcut will not be created." >> ${PREFIX}/.message.txt
     echo "Please update to menuinst >=${menuinst_min_version} in the base environment and reinstall Spyder." >> ${PREFIX}/.message.txt
+    return
+fi
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # Set "Show scroll bars" to "Always" for Spyder's application bundle ID
+    # spyder-ide/spyder#13118
+    defaults write ${cfbundleid} AppleShowScrollBars Always
 fi


### PR DESCRIPTION
Set system preference to always show scroll bars on macOS for Spyder's application bundle ID

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
