### PR TITLE
Revert schema spec for menuinst json files on Windows

### DIFF
--- a/recipe/spyder-menu-win.json
+++ b/recipe/spyder-menu-win.json
@@ -1,5 +1,6 @@
 {
-    "$schema": "https://schemas.conda.org/menuinst/menuinst-1-1-2.schema.json",
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "$id": "https://schemas.conda.io/menuinst-1.schema.json",
     "menu_name": "{{ DISTRIBUTION_NAME }} spyder",
     "menu_items": [
         {


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Updated schema spec requires `conda-standalone>24`. Do not update schema spec until we can enforce update to `conda-standalone`.